### PR TITLE
Do not wrap update install service path with quotes

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -240,7 +240,10 @@ RingtailClient.prototype.update = function update(next) {
 RingtailClient.prototype.setUpdatePath = function setUpdatePath(value, next) {
   var deferred = new Q.defer()    
     , updateUrl = this.updateUrl
-    , url = updateUrl + '?value=' + encodeURIComponent(value);
+    , url = updateUrl + '?value=' + value;
+
+
+  debug('setting url %s', url);
 
   request.get(url, function(err, response, body) {   
     if(response && response.statusCode === 200) {    

--- a/test/client.js
+++ b/test/client.js
@@ -117,7 +117,7 @@ describe('RingtailClient', function() {
       requestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.setUpdatePath(value, function() {        
         expect(requestStub.calledOnce).to.be.true;
-        expect(requestStub.getCall(0).args[0]).to.equal(instance.updateUrl + '?value=' + '%5C%5CtestPath');
+        expect(requestStub.getCall(0).args[0]).to.equal(instance.updateUrl + '?value=' + value);
         done();
       }); 
     });


### PR DESCRIPTION
The end point API does not support quote wrapping.  Avoiding a breaking
change.