### PR TITLE
IsRunning now allows jobs to continue if the endpoint doesn't have the API.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -10,20 +10,20 @@ var debug         = require('debug')('deployer-client')
 function RingtailClient(options) {
   _.extend(this, options); 
 
-  this.installUrl    = 'http://' + this.serviceHost + ':8080/api/installer';
+  this.installUrl         = 'http://' + this.serviceHost + ':8080/api/installer';
   this.installDiagnositcUrl    = 'http://' + this.serviceHost + ':8080/api/installDiagnostic';
   this.installDiagnositcResultUrl    = 'http://' + this.serviceHost + ':8080/api/config?filename=masterLog.txt';
-  this.statusUrl     = 'http://' + this.serviceHost + ':8080/api/status';
-  this.isUpUrl       = 'http://' + this.serviceHost + ':8080/api/help';
-  this.updateUrl     = 'http://' + this.serviceHost + ':8080/api/UpdateInstallerService';
-  this.configUrl     = 'http://' + this.serviceHost + ':8080/api/config';
-  this.installedUrl  = 'http://' + this.serviceHost + ':8080/api/installedBuilds';
-  this.launchKeysUrl = 'http://' + this.serviceHost + ':8080/api/AvailableFeatures';
-  this.retryUrl      = 'http://' + this.serviceHost + ':8080/api/retry';
-  this.preReqUrl     = 'http://' + this.serviceHost + ':8080/api/Prerequisite?minGB=7';
+  this.statusUrl          = 'http://' + this.serviceHost + ':8080/api/status';
+  this.isUpUrl            = 'http://' + this.serviceHost + ':8080/api/help';
+  this.updateUrl          = 'http://' + this.serviceHost + ':8080/api/UpdateInstallerService';
+  this.configUrl          = 'http://' + this.serviceHost + ':8080/api/config';
+  this.installedUrl       = 'http://' + this.serviceHost + ':8080/api/installedBuilds';
+  this.launchKeysUrl      = 'http://' + this.serviceHost + ':8080/api/AvailableFeatures';
+  this.retryUrl           = 'http://' + this.serviceHost + ':8080/api/retry';
+  this.preReqUrl          = 'http://' + this.serviceHost + ':8080/api/Prerequisite?minGB=7';
   this.setMasterConfigUrl = 'http://' + this.serviceHost + ':8080/api/UpdateServiceConfig/Update';
   this.setDeploymentConfigUrl = 'http://' + this.serviceHost + ':8080/api/UpdateDeploymentConfig/Update'
-  this.isRunningUrl  = 'http://' + this.serviceHost + ':8080/api/IsRunning';
+  this.isRunningUrl       = 'http://' + this.serviceHost + ':8080/api/IsRunning';
 
   this.pollInterval             = 15 * 1000;    // 15 seconds
   this.requestTimeout           = 10 * 1000;    // 10 seconds
@@ -483,16 +483,17 @@ RingtailClient.prototype.isJobRunning = function isJobRunning(next) {
     ;
 
     request.get({url: isRunningUrl, timeout: requestTimeout }, function(err, response, body) {
-      var result = false;
       if(response && response.statusCode === 200) {
         requestResponse = (body === "true");
         deferred.resolve(requestResponse);
       } 
       else if(err) {
-        deferred.reject(result);
+        // Have to fail open in case the other end doesn't have the API yet - or some other error has happened.
+        // once all consumers are on service version 2.11.0, we can change this to '.reject(err)'
+        deferred.resolve(false);
       }
       else {
-        deferred.reject(result);
+        deferred.reject(false);
       }
     });
         


### PR DESCRIPTION
On the first upgrade with the new website, some sites may still be
running an older version of the service.  In those cases, they were
responding with 'Unable to tell if a job is running', which is true, but
will cause end-users to get confused and ask for help.

In this situation, we should eat the error, and continue with other
validations.