### PR TITLE
Fixes a fail case in the client.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -488,12 +488,12 @@ RingtailClient.prototype.isJobRunning = function isJobRunning(next) {
         deferred.resolve(requestResponse);
       } 
       else if(err) {
-        // Have to fail open in case the other end doesn't have the API yet - or some other error has happened.
-        // once all consumers are on service version 2.11.0, we can change this to '.reject(err)'
+        // Have to fail open in case the other end doesn't have the API yet.
         deferred.resolve(false);
       }
       else {
-        deferred.reject(false);
+        // Have to fail open in case the other end doesn't have the API yet.
+        deferred.resolve(false);
       }
     });
         


### PR DESCRIPTION
When the server machine doesn't have the API - the validation should
allow it to continue.