### PR TITLE
Enable tls support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,22 +9,28 @@ var debug         = require('debug')('deployer-client')
 
 function RingtailClient(options) {
   _.extend(this, options); 
+  this.sslEnabled = (options.sslMode && options.sslMode.toLowerCase() !== 'none');
+  this.sslStrict = (options.sslMode && options.sslMode.toLowerCase() === 'strict');
 
-  this.installUrl         = 'http://' + this.serviceHost + ':8080/api/installer';
-  this.installDiagnositcUrl    = 'http://' + this.serviceHost + ':8080/api/installDiagnostic';
-  this.installDiagnositcResultUrl    = 'http://' + this.serviceHost + ':8080/api/config?filename=masterLog.txt';
-  this.statusUrl          = 'http://' + this.serviceHost + ':8080/api/status';
-  this.isUpUrl            = 'http://' + this.serviceHost + ':8080/api/help';
-  this.updateUrl          = 'http://' + this.serviceHost + ':8080/api/UpdateInstallerService';
-  this.configUrl          = 'http://' + this.serviceHost + ':8080/api/config';
-  this.installedUrl       = 'http://' + this.serviceHost + ':8080/api/installedBuilds';
-  this.launchKeysUrl      = 'http://' + this.serviceHost + ':8080/api/AvailableFeatures';
-  this.existingConfigsUrl = 'http://' + this.serviceHost + ':8080/api/ExistingConfiguration';
-  this.retryUrl           = 'http://' + this.serviceHost + ':8080/api/retry';
-  this.preReqUrl          = 'http://' + this.serviceHost + ':8080/api/Prerequisite?minGB=7';
-  this.setMasterConfigUrl = 'http://' + this.serviceHost + ':8080/api/UpdateServiceConfig/Update';
-  this.setDeploymentConfigUrl = 'http://' + this.serviceHost + ':8080/api/UpdateDeploymentConfig/Update';
-  this.isRunningUrl       = 'http://' + this.serviceHost + ':8080/api/IsRunning';
+  this.serviceProtocol = (this.sslEnabled)? 'https' : 'http';
+  this.servicePort = '8080';
+  this.serviceRootUrl = `${this.serviceProtocol}://${this.serviceHost}:${this.servicePort}/api`; 
+
+  this.installUrl                 = this.serviceRootUrl + '/installer';
+  this.installDiagnositcUrl       = this.serviceRootUrl + '/installDiagnostic';
+  this.installDiagnositcResultUrl = this.serviceRootUrl + '/config?filename=masterLog.txt';
+  this.statusUrl                  = this.serviceRootUrl + '/status';
+  this.isUpUrl                    = this.serviceRootUrl + '/help';
+  this.updateUrl                  = this.serviceRootUrl + '/UpdateInstallerService';
+  this.configUrl                  = this.serviceRootUrl + '/config';
+  this.installedUrl               = this.serviceRootUrl + '/installedBuilds';
+  this.launchKeysUrl              = this.serviceRootUrl + '/AvailableFeatures';
+  this.existingConfigsUrl         = this.serviceRootUrl + '/ExistingConfiguration';
+  this.retryUrl                   = this.serviceRootUrl + '/retry';
+  this.preReqUrl                  = this.serviceRootUrl + '/Prerequisite?minGB=7';
+  this.setMasterConfigUrl         = this.serviceRootUrl + '/UpdateServiceConfig/Update';
+  this.setDeploymentConfigUrl     = this.serviceRootUrl + '/UpdateDeploymentConfig/Update';
+  this.isRunningUrl               = this.serviceRootUrl + '/IsRunning';
 
   this.pollInterval             = 15 * 1000;    // 15 seconds
   this.requestTimeout           = 10 * 1000;    // 10 seconds
@@ -40,6 +46,37 @@ function RingtailClient(options) {
 module.exports = RingtailClient;
 
 
+RingtailClient.prototype.assignGetRequest = function assignGetRequest(url, promise, resolveFn) {
+  let requestOptions = this.getRequestOptions(url);
+
+  request.get(requestOptions, function(err, response, body) {   
+    if(response && response.statusCode === 200) {  
+      let resolveOut = {Err: null, Val: null};
+      if (resolveFn) {
+        resolveFn(body, resolveOut);
+        if (resolveOut.Err) {promise.reject(resolveOut.Err);}
+        else if (resolveOut.Val) {promise.resolve(resolveOut.Val);}
+        else {promise.resolve(body);}
+      }
+      else {promise.resolve(body);}
+    } else if(err) {
+      promise.reject(err);
+    } else {
+      promise.reject(response);
+    }      
+  });
+}
+
+
+RingtailClient.prototype.getRequestOptions = function getRequestOptions(url) {
+  let requestOptions = {url: url, timeout: this.requestTimeout};
+  if (this.sslEnabled) {
+    requestOptions.strictSSL = this.sslStrict;
+  }
+
+  return requestOptions;
+}
+
 
 /**
  * Sets the config value
@@ -50,28 +87,24 @@ module.exports = RingtailClient;
  * @return {promise}
  */
 RingtailClient.prototype.setConfig = function setConfig(key, value, next) {
-  var deferred = new Q.defer()    
     , configUrl = this.configUrl
     , url;
+    , url = this.configUrl + '?key=' + encodeURIComponent(key) + '&value=' + encodeURIComponent(value)
+    , resolveFn = function(body, resolveOut){
+          resolveOut.Err = 'Config value not set correctly: \'' + config[key].value + '\' expected to be \'' + value + '\'';
+        } else {resolveOut.Val = value};
+    };
   
-  url = configUrl + '?key=' + encodeURIComponent(key) + '&value=' + encodeURIComponent(value);  
-  request.get(url, function(err, response, body) {   
+  this.assignGetRequest(url, deferred, resolveFn);
+  
     if(response && response.statusCode === 200) {    
       // validate that config was set correctly
       var config = configParser.parse(body);
       /* jshint es5:false */
-      /* jshint eqeqeq:false */
-      if(config[key] && config[key].value != value) {
-        deferred.reject('Config value not set correctly: \'' + config[key].value + '\' expected to be \'' + value + '\'');
-      } else {
-        deferred.resolve(value);
-      }
-      /*jshint eqeqeq:true*/
     } else if(err) {
       deferred.reject(err);
     } else {
       deferred.reject(response);
-    }      
   });
 
   return deferred.promise.nodeify(next); 
@@ -118,22 +151,14 @@ RingtailClient.prototype.setConfigs = function setConfigs(opts, next) {
  * @return {promise}
  */
 RingtailClient.prototype.getConfigs = function getConfigs(next) {
-  var deferred = new Q.defer()    
-    , configUrl = this.configUrl
-    , url;
+  let deferred = new Q.defer();
     
-  request.get(configUrl, function(err, response, body) {
-    if(response && response.status === 200) {
-      deferred.resolve(body);
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);  
-    }      
-  });
-
-  return deferred.promise.nodeify(next);
+  this.assignGetRequest(this.configUrl, deferred);
+  
+  return deferred.promise.nodeify(next)
+    
 };
+
 
 /**
  * Gets the config values
@@ -142,31 +167,23 @@ RingtailClient.prototype.getConfigs = function getConfigs(next) {
  * @return {promise}
  */
 RingtailClient.prototype.getExistingConfigs = function getExistingConfigs(next) {
-  var deferred = new Q.defer()    
-    , existingConfigsUrl = this.existingConfigsUrl
-    , url;
+  let deferred = new Q.defer()    
+    , resolveFn = function(body, resolveOut){
+        let x = JSON.parse(body)
+          , translatedExistingConfigs = {};
     
-  request.get(existingConfigsUrl, function(err, response, body) {
-    if(response && response.statusCode === 200) {
-      let x = JSON.parse(body);
-      let translatedExistingConfigs = {};
+        _.each(x, function(config) {
+          // each row should come in of the shape [{ Key: '', Value: ''}]   ..if it doesn't come in that shape, try parsing as object.
+          let cfg = Array.isArray(config) && config.length === 1 ? config[0] : config;
+          translatedExistingConfigs[cfg.Key] = cfg.Value;
+        });
+        resolveOut.Val = translatedExistingConfigs;
+    };
   
-      _.each(x, function(config) {
-        // each row should come in of the shape [{ Key: '', Value: ''}]   ..if it doesn't come in that shape, try parsing as object.
-        let cfg = Array.isArray(config) && config.length === 1 ? config[0] : config;
-        translatedExistingConfigs[cfg.Key] = cfg.Value;
-      });
-      deferred.resolve(translatedExistingConfigs);
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);  
-    }
-  });
-
-  return deferred.promise.nodeify(next);
+  this.assignGetRequest(this.existingConfigsUrl, deferred, resolveFn);
+  
+  return deferred.promise.nodeify(next); 
 };
-
 
 
 /**
@@ -177,42 +194,24 @@ RingtailClient.prototype.getExistingConfigs = function getExistingConfigs(next) 
  * @return {promise}
  */
 RingtailClient.prototype.getLaunchKeys = function getLaunchKeys(dropLocation, next) {
-  var deferred = new Q.defer()    
-    , launchKeysUrl = this.launchKeysUrl
-    , url;
+  let deferred = new Q.defer()    
+    , url = this.launchKeysUrl + '?dropLocation=' + encodeURIComponent(dropLocation);
+    
+    this.assignGetRequest(url, deferred);
   
-  url = launchKeysUrl + '?dropLocation=' + encodeURIComponent(dropLocation);
-  request.get(url, function(err, response, body) {   
-    if(response && response.statusCode === 200) {  
-      deferred.resolve(body);
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);
-    }      
-  });
-
-  return deferred.promise.nodeify(next); 
+  return deferred.promise.nodeify(next)
 };
+
 
 RingtailClient.prototype.getLitKeys = function getLitKeys(connectionString, dropLocation, next) {
-  var deferred = new Q.defer()    
-    , launchKeysUrl = this.launchKeysUrl
-    , url;
+  let deferred = new Q.defer()    
+    , url = this.launchKeysUrl + '?connectionString=' + encodeURIComponent(connectionString) + '&dropLocation=' + dropLocation;
   
-  url = launchKeysUrl + '?connectionString=' + encodeURIComponent(connectionString) + '&dropLocation=' + dropLocation;
-  request.get(url, function(err, response, body) {   
-    if(response && response.statusCode === 200) {  
-      deferred.resolve(body);
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);
-    }      
-  });
-
-  return deferred.promise.nodeify(next); 
+  this.assignGetRequest(url, deferred);
+  
+  return deferred.promise.nodeify(next)
 };
+
 
 /**
  * Start an installation
@@ -220,14 +219,10 @@ RingtailClient.prototype.getLitKeys = function getLitKeys(connectionString, drop
  * @return {promise}
  */ 
 RingtailClient.prototype.install = function install(next) {
-  var deferred = new Q.defer()    
-    , installUrl = this.installUrl    
-    ;
-
-  request.get(installUrl, function(err, response, body) {
-    deferred.resolve(body);
-  }); 
-
+  let deferred = new Q.defer();
+    
+  this.assignGetRequest(this.installUrl, deferred);
+  
   return deferred.promise.nodeify(next);
 };
 
@@ -238,13 +233,9 @@ RingtailClient.prototype.install = function install(next) {
  * @return {promise}
  */ 
 RingtailClient.prototype.retry = function retry(next) {
-  var deferred = new Q.defer()    
-    , retryUrl = this.retryUrl    
-    ;
-
-  request.get(retryUrl, function(err, response, body) {
-    deferred.resolve(body);
-  }); 
+  let deferred = new Q.defer();
+    
+  this.assignGetRequest(this.retryUrl, deferred);
 
   return deferred.promise.nodeify(next);
 };
@@ -256,18 +247,12 @@ RingtailClient.prototype.retry = function retry(next) {
  * @return {promise}
  */ 
 RingtailClient.prototype.validate = function validate(next) {
-  var deferred = new Q.defer()    
-    , installDiagnositcUrl = this.installDiagnositcUrl    
-    ;
+  let deferred = new Q.defer();
 
-  request.get(installDiagnositcUrl, function(err, response, body) {
-    deferred.resolve(body);
-  }); 
+  this.assignGetRequest(this.installDiagnositcUrl, deferred);
 
   return deferred.promise.nodeify(next);
 };
-
-
 
 
 /**
@@ -278,12 +263,12 @@ RingtailClient.prototype.validate = function validate(next) {
  * @return {promise} 
  */
 RingtailClient.prototype.update = function update(next) {
-  var updateUrl = this.updateUrl
-    , delay = this.updateDelay
-    , deferred = Q.defer();
+  var delay = this.updateDelay
+    , deferred = Q.defer()
+    , requestOptions = this.getRequestOptions(this.updateUrl);
 
   setTimeout(function() {
-    request.get(updateUrl, function(err, res, body) {
+    request.get(requestOptions, function(err, res, body) {
       setTimeout(function() {
         if(err) deferred.reject(err);
         else deferred.resolve(body);
@@ -293,6 +278,7 @@ RingtailClient.prototype.update = function update(next) {
 
   return deferred.promise.nodeify(next);
 };
+
 
 /**
  * Changes the drop location that the service is configured to use
@@ -305,26 +291,16 @@ RingtailClient.prototype.setUpdatePath = function setUpdatePath(value, next) {
   var deferred = new Q.defer()    
     , updateUrl = this.updateUrl
     , normalizedValue = value.replace(/['"]+/g, '')
-    , url = updateUrl + '?value=' + normalizedValue;
+    , url = updateUrl + '?value=' + normalizedValue
+    , resolveFn = function(body, resolveOut){
+        resolveOut.Val = configParser.parse(body);
+    };
 
-
-  debug('setting url %s', url);
-
-  request.get(url, function(err, response, body) {   
-    if(response && response.statusCode === 200) {    
-      // validate that config was set correctly
-      var config = configParser.parse(body);
-      deferred.resolve(value);
-      /*jshint eqeqeq:true*/
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);
-    }      
-  });
+  this.assignGetRequest(url, deferred, resolveFn);
 
   return deferred.promise.nodeify(next); 
 };
+
 
 /**
  * Set username and password for running the service
@@ -334,15 +310,11 @@ RingtailClient.prototype.setUpdatePath = function setUpdatePath(value, next) {
  */
 RingtailClient.prototype.setMasterCredentials = function setMasterCredentials(credentials, next) {
   var deferred = new Q.defer()    
-    , url = this.setMasterConfigUrl;
+    , url = this.setMasterConfigUrl
+    , options = Object.assign({}, {method:'POST', json: credentials}, this.getRequestOptions(url));
 
     debug('updating master credentials');
-    var options = {
-      uri:url,
-      method: 'POST',
-      json: credentials
-    };
-
+    
     request.post(options, function(err, response, body) {
       if(response && response.statusCode === 200) {
         deferred.resolve(body);
@@ -352,20 +324,17 @@ RingtailClient.prototype.setMasterCredentials = function setMasterCredentials(cr
         deferred.reject(response);
       }
     });
+
     return deferred.promise.nodeify(next);
 };
+
 
 RingtailClient.prototype.setDeploymentConfig = function setDeploymentConfig(config, next) {
   var deferred = new Q.defer()    
-    , url = this.setDeploymentConfigUrl;
+    , url = this.setDeploymentConfigUrl
+    , options = Object.assign({}, {method:'POST', json: config}, this.getRequestOptions(url));
 
     debug('setting deployment config');
-
-    var options = {
-      uri:url,
-      method: 'POST',
-      json: config
-    };
 
     request.post(options, function(err, response, body) {
       if(response && response.statusCode === 200) {
@@ -376,8 +345,10 @@ RingtailClient.prototype.setDeploymentConfig = function setDeploymentConfig(conf
         deferred.reject(response);
       }
     });
+
     return deferred.promise.nodeify(next);
 };
+
 
 /**
  * Gets the build status from the install service
@@ -386,23 +357,13 @@ RingtailClient.prototype.setDeploymentConfig = function setDeploymentConfig(conf
  * @return {promise}
  */
 RingtailClient.prototype.status = function status(next) {
-  var statusUrl = this.statusUrl    
-    , requestTimeout = this.requestTimeout
-    , deferred = Q.defer()
-    ;
+  var deferred = Q.defer();
 
-  request.get({ url: statusUrl, timeout: requestTimeout }, function(err, response, body) {    
-    if(response && response.statusCode === 200) {      
-      deferred.resolve(body);    
-    } else if(err) {
-      deferred.reject(err);      
-    } else {    
-      deferred.reject(response);
-    }
-  }); 
+  this.assignGetRequest(this.statusUrl, deferred);
 
   return deferred.promise.nodeify(next); 
 };
+
 
 /**
  * Gets the validation output from the install service
@@ -411,20 +372,9 @@ RingtailClient.prototype.status = function status(next) {
  * @return {promise}
  */
 RingtailClient.prototype.installDiagnositcResult = function installDiagnositcResult(next) {
-  var statusUrl = this.installDiagnositcResultUrl    
-    , requestTimeout = this.requestTimeout
-    , deferred = Q.defer()
-    ;
+  var deferred = Q.defer();
 
-  request.get({ url: statusUrl, timeout: requestTimeout }, function(err, response, body) {    
-    if(response && response.statusCode === 200) {      
-      deferred.resolve(body);    
-    } else if(err) {
-      deferred.reject(err);      
-    } else {    
-      deferred.reject(response);
-    }
-  }); 
+  this.assignGetRequest(this.installDiagnositcResultUrl, deferred);
 
   return deferred.promise.nodeify(next); 
 };
@@ -437,22 +387,12 @@ RingtailClient.prototype.installDiagnositcResult = function installDiagnositcRes
  * @return {promise}
  */
 RingtailClient.prototype.installed = function installed(next) {
-  var installedUrl = this.installedUrl    
-    , requestTimeout = this.requestTimeout
-    , deferred = Q.defer()    
-    ;
+  let deferred = Q.defer()    
+    , resolveFn = function(body, resolveOut){
+        resolveOut.Val = htmlParser.createArray(body);
+    };
 
-  request.get({ url: installedUrl, timeout: requestTimeout }, function(err, response, body) {                  
-    var result;
-    if(response && response.statusCode === 200) {      
-      result = htmlParser.createArray(body);
-      deferred.resolve(result);    
-    } else if(err) {
-      deferred.reject(err);      
-    } else {    
-      deferred.reject(response);
-    }
-  }); 
+  this.assignGetRequest(this.installedUrl, deferred, resolveFn);
 
   return deferred.promise.nodeify(next); 
 };
@@ -466,10 +406,8 @@ RingtailClient.prototype.installed = function installed(next) {
  * @return {promise}
  */
 RingtailClient.prototype.waitForService = function waitForService( next) { 
-  var statusUrl = this.statusUrl
-    , pollInterval = this.pollInterval
+  var pollInterval = this.pollInterval
     , waitTimeout  = this.waitTimeout
-    , requestTimeout = this.requestTimeout
     , me = this
     , fn 
     ;
@@ -482,6 +420,7 @@ RingtailClient.prototype.waitForService = function waitForService( next) {
     .fulfilled(fn, pollInterval, waitTimeout)
     .nodeify(next);
 };
+
 
 /** 
  * Utility function that waits until the service is available
@@ -491,10 +430,8 @@ RingtailClient.prototype.waitForService = function waitForService( next) {
  * @return {promise}
  */
 RingtailClient.prototype.waitForServiceLimited = function waitForServiceLimited(waitTime, next) { 
-  var statusUrl = this.statusUrl
-    , pollInterval = this.pollIntervalDiagnostic
+  var pollInterval = this.pollIntervalDiagnostic
     , waitTimeout  = waitTime ? waitTime : this.waitTimeout
-    , requestTimeout = this.requestTimeout
     , me = this
     , fn 
     ;
@@ -508,31 +445,32 @@ RingtailClient.prototype.waitForServiceLimited = function waitForServiceLimited(
     .nodeify(next);
 };
 
+
 RingtailClient.prototype.isJobRunning = function isJobRunning(next) {
   // If there's no endpoint for this on the server or an error, return a green light
   // In short, false is actually passing the validation check that calls this function.
-  var isRunningUrl = this.isRunningUrl
-    , requestTimeout = this.requestTimeout
+  let requestOptions = this.getRequestOptions(this.isRunningUrl)
     , deferred = Q.defer()
     ;
 
-    request.get({url: isRunningUrl, timeout: requestTimeout }, function(err, response, body) {
-      if(response && response.statusCode === 200) {
-        let requestResponse = (body === 'true');
-        deferred.resolve(requestResponse);
-      } 
-      else if(err) {
-        // Have to fail open in case the other end doesn't have the API yet.
-        deferred.resolve(false);
-      }
-      else {
-        // Have to fail open in case the other end doesn't have the API yet.
-        deferred.resolve(false);
-      }
-    });
-        
-    return deferred.promise.nodeify(next);
+  request.get(requestOptions, function(err, response, body) {
+    if(response && response.statusCode === 200) {
+      let requestResponse = (body === 'true');
+      deferred.resolve(requestResponse);
+    } 
+    else if(err) {
+      // Have to fail open in case the other end doesn't have the API yet.
+      deferred.resolve(false);
+    }
+    else {
+      // Have to fail open in case the other end doesn't have the API yet.
+      deferred.resolve(false);
+    }
+  });
+      
+  return deferred.promise.nodeify(next);
 };
+
 
 /**
  * Gets the storage information from the install service
@@ -541,23 +479,13 @@ RingtailClient.prototype.isJobRunning = function isJobRunning(next) {
  * @return {promise}
  */
 RingtailClient.prototype.prerequisites = function installed(next) {
-  var preReqUrl = this.preReqUrl    
-    , requestTimeout = this.requestTimeout
-    , deferred = Q.defer()    
-    ;
+  let deferred = Q.defer();
   
-  request.get({url: preReqUrl}, function(err, response, body) {                  
-    if(response && response.statusCode === 200) {  
-      deferred.resolve(body);    
-    } else if(err) {
-      deferred.reject(err);      
-    } else {    
-      deferred.resolve(body);
-    }
-  }); 
+  this.assignGetRequest(this.preReqUrl, deferred);
 
   return deferred.promise.nodeify(next); 
 };
+
 
 /**
  * Utility function that waits for an install to complete. Note you
@@ -565,11 +493,9 @@ RingtailClient.prototype.prerequisites = function installed(next) {
  *
  */
 RingtailClient.prototype.waitForInstall = function waitForInstall(status, next) {
-  var statusUrl       = this.statusUrl
-    , pollInterval    = this.pollInterval
+  var pollInterval    = this.pollInterval
     , waitTimeout     = this.installTimeout
     , installDelay    = this.installDelay
-    , requestTimeout  = this.requestTimeout    
     , me              = this
     , fn 
     ;
@@ -637,11 +563,9 @@ RingtailClient.prototype.waitForInstall = function waitForInstall(status, next) 
  *
  */
 RingtailClient.prototype.waitForValidate = function waitForValidate(status, next) {
-  var statusUrl       = this.installDiagnositcResultUrl
-    , pollInterval    = this.pollIntervalDiagnostic
+  var pollInterval    = this.pollIntervalDiagnostic
     , waitTimeout     = this.installDiagnosticTimeout
     , installDelay    = this.installDiagnosticDelay
-    , requestTimeout  = this.requestTimeout    
     , me              = this
     , fn 
     ;

--- a/lib/client.js
+++ b/lib/client.js
@@ -87,26 +87,17 @@ RingtailClient.prototype.getRequestOptions = function getRequestOptions(url) {
  * @return {promise}
  */
 RingtailClient.prototype.setConfig = function setConfig(key, value, next) {
-    , configUrl = this.configUrl
-    , url;
+  let deferred = new Q.defer()    
     , url = this.configUrl + '?key=' + encodeURIComponent(key) + '&value=' + encodeURIComponent(value)
     , resolveFn = function(body, resolveOut){
+        let config = configParser.parse(body);
+        if(config[key] && config[key].value != value) { 
           resolveOut.Err = 'Config value not set correctly: \'' + config[key].value + '\' expected to be \'' + value + '\'';
         } else {resolveOut.Val = value};
     };
   
   this.assignGetRequest(url, deferred, resolveFn);
   
-    if(response && response.statusCode === 200) {    
-      // validate that config was set correctly
-      var config = configParser.parse(body);
-      /* jshint es5:false */
-    } else if(err) {
-      deferred.reject(err);
-    } else {
-      deferred.reject(response);
-  });
-
   return deferred.promise.nodeify(next); 
 };
 

--- a/test/client.js
+++ b/test/client.js
@@ -157,7 +157,7 @@ describe('RingtailClient', function() {
       getRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.setUpdatePath(value, function() {        
         expect(getRequestStub.calledOnce).to.be.true;
-        expect(getRequestStub.getCall(0).args[0]).to.equal(instance.updateUrl + '?value=' + value);
+        expect(getRequestStub.getCall(0).args[0].url).to.equal(instance.updateUrl + '?value=' + value);
         done();
       }); 
     });
@@ -192,7 +192,7 @@ describe('RingtailClient', function() {
       instance.updateDelay = 1;
       instance.update(function() {        
         expect(getRequestStub.calledOnce).to.be.true;
-        expect(getRequestStub.getCall(0).args[0]).to.equal(instance.updateUrl);
+        expect(getRequestStub.getCall(0).args[0].url).to.equal(instance.updateUrl);
         done();
       }); 
     });
@@ -216,7 +216,7 @@ describe('RingtailClient', function() {
       getRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.setConfig('Common|Test', 'value', function(err, result) {                
         expect(getRequestStub.calledOnce).to.be.true;
-        expect(getRequestStub.getCall(0).args[0]).to.equal(instance.configUrl + '?key=Common%7CTest&value=value');
+        expect(getRequestStub.getCall(0).args[0].url).to.equal(instance.configUrl + '?key=Common%7CTest&value=value');
         done();
       });      
     });
@@ -267,9 +267,9 @@ describe('RingtailClient', function() {
       getRequestStub.onCall(2).yields(null, { statusCode: 200}, '<p>Common|Test3=\\"test3\\"</p>');
       instance.setConfigs(configs, function(err, result) {                
         expect(getRequestStub.callCount).to.equal(3);        
-        expect(getRequestStub.getCall(0).args[0]).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest1&value=test1');
-        expect(getRequestStub.getCall(1).args[0]).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest2&value=test2');
-        expect(getRequestStub.getCall(2).args[0]).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest3&value=test3');
+        expect(getRequestStub.getCall(0).args[0].url).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest1&value=test1');
+        expect(getRequestStub.getCall(1).args[0].url).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest2&value=test2');
+        expect(getRequestStub.getCall(2).args[0].url).to.equal('http://127.0.0.1:8080/api/config?key=Common%7CTest3&value=test3');
         done();
       });      
     });
@@ -299,7 +299,7 @@ describe('RingtailClient', function() {
       postRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.setMasterCredentials(credentials, function(err, result) {
         expect(postRequestStub.callCount).to.equal(1);
-        expect(postRequestStub.getCall(0).args[0].uri).to.equal('http://127.0.0.1:8080/api/UpdateServiceConfig/Update');
+        expect(postRequestStub.getCall(0).args[0].url).to.equal('http://127.0.0.1:8080/api/UpdateServiceConfig/Update');
         expect(postRequestStub.getCall(0).args[0].json.MasterRunnerUser).to.equal('testUser');
         expect(postRequestStub.getCall(0).args[0].json.MasterRunnerPass).to.equal('testPass');
         done();
@@ -316,7 +316,7 @@ describe('RingtailClient', function() {
       postRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.setDeploymentConfig(config, function(err, result) {
         expect(postRequestStub.callCount).to.equal(1);
-        expect(postRequestStub.getCall(0).args[0].uri).to.equal('http://127.0.0.1:8080/api/UpdateDeploymentConfig/Update');
+        expect(postRequestStub.getCall(0).args[0].url).to.equal('http://127.0.0.1:8080/api/UpdateDeploymentConfig/Update');
         expect(postRequestStub.getCall(0).args[0].json['Common|BRANCH_NAME']).to.equal('Main');
         expect(postRequestStub.getCall(0).args[0].json['Common|FILE_DELETIONS']).to.equal('');
         done();
@@ -330,7 +330,7 @@ describe('RingtailClient', function() {
       getRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.install(function(err, result) {                
         expect(getRequestStub.calledOnce).to.be.true;
-        expect(getRequestStub.getCall(0).args[0]).to.equal(instance.installUrl);
+        expect(getRequestStub.getCall(0).args[0].url).to.equal(instance.installUrl);
         done();
       });      
     });
@@ -456,7 +456,7 @@ describe('RingtailClient', function() {
       getRequestStub.onCall(0).yields(null, { statusCode: 200}, 'success');
       instance.validate(function(err, result) {                
         expect(getRequestStub.calledOnce).to.be.true;
-        expect(getRequestStub.getCall(0).args[0]).to.equal(instance.installDiagnositcUrl);
+        expect(getRequestStub.getCall(0).args[0].url).to.equal(instance.installDiagnositcUrl);
         done();
       });      
     });


### PR DESCRIPTION
Made the following changes:

- Add support for a new security flag, 'sslMode' to be supplied by the caller.  
- Consoldiated request submission to a single method so additional, security related options can be managed in one place

What I did NOT do is consolidate the code from this project into the ringtail-deploy-web project.  One option is to cancel this PR and simply add the files from this PR (with my changes) into ringtail-deploy-web.  Let me know if you think that is better than going ahead with this PR as is and merging the client code into the web code 'later'.