### PR TITLE
Add null check to constructor for security settings

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -9,8 +9,10 @@ var debug         = require('debug')('deployer-client')
 
 function RingtailClient(options) {
   _.extend(this, options); 
-  this.sslEnabled = (options.sslMode && options.sslMode.toLowerCase() !== 'none');
-  this.sslStrict = (options.sslMode && options.sslMode.toLowerCase() === 'strict');
+  if (options) {
+    this.sslEnabled = (options.sslMode && options.sslMode.toLowerCase() !== 'none');
+    this.sslStrict = (options.sslMode && options.sslMode.toLowerCase() === 'strict');
+  }
 
   this.serviceProtocol = (this.sslEnabled)? 'https' : 'http';
   this.servicePort = '8080';


### PR DESCRIPTION
Discovered this little gotcha while working on a unit test of something else